### PR TITLE
Run import in Github actions

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,34 @@
+name: Run
+env:
+  HUBSPOT_API_KEY: ${{ secrets.HUBSPOT_API_KEY }}
+  HUBSPOT_DEAL_STAGE_ID: ${{ secrets.HUBSPOT_DEAL_STAGE_ID }}
+  HUBSPOT_LIST_ID: ${{ secrets.HUBSPOT_LIST_ID }}
+  HUBSPOT_PIPELINE_ID: ${{ secrets.HUBSPOT_PIPELINE_ID }}
+  HUBSPOT_PORTAL_ID: ${{ secrets.HUBSPOT_PORTAL_ID }}
+  SLACK_ERROR_WEBHOOK_URL: ${{ secrets. SLACK_ERROR_WEBHOOK_URL }}
+  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+on:
+  schedule:
+    - cron: '0 9 * * 1-5'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.6.x
+    - name: Set up cache
+      uses: actions/cache@preview
+      with:
+        path: ./vendor/bundle
+        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gem-
+    - name: Fetch latest opportunities
+      run: bundle exec rake opportunities:import


### PR DESCRIPTION
This moves the running of Golden Retriever into Github Actions, rather than using Heroku.