### PR TITLE
Use keepalive-workflow at the end of run

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,3 +26,8 @@ jobs:
           bundle install --jobs 4 --retry 3 --path ./vendor/bundle
       - name: Fetch latest opportunities
         run: script/run
+      - uses: dxw/keepalive-workflow@c9ef16
+        with:
+          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
+          committer_username: dxw-rails-user
+          committer_email: rails@dxw.com


### PR DESCRIPTION
This adds [keepalive-workflow](https://github.com/gautamkrishnar/keepalive-workflow) to the end of the scheduled task. After 60 days with no activity on the master branch, Github considers a repo "inactive" and will stop all scheduled tasks from running. This  actions adds an empty commit every 50 days to the master branch of the repo to keep the repo "active"  and make sure the scheduled task continues to run after the 60 day period. It's a bit of a blunt instrument, but so far, there doesn't seem to be an alternative.

I've forked the original repo as I feel a bit iffy about having untrusted code automatically pushing to our repos, but I've reviewed what the action does and feel confident that the snapshot in time we have does the correct thing.