### PR TITLE
Set SHA correctly

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -26,7 +26,7 @@ jobs:
           bundle install --jobs 4 --retry 3 --path ./vendor/bundle
       - name: Fetch latest opportunities
         run: script/run
-      - uses: dxw/keepalive-workflow@c9ef16
+      - uses: dxw/keepalive-workflow@master
         with:
           commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
           committer_username: dxw-rails-user


### PR DESCRIPTION
The ref I used in the keepalive workflow was set to the shortened version of a commit SHA, which GitHub Actions doesn't support. As we're using our own fork of the action, I think we're safe to use `master` here instead.